### PR TITLE
gca(projection='3d') is deprecated, fixed.

### DIFF
--- a/util/camera_pose_visualizer.py
+++ b/util/camera_pose_visualizer.py
@@ -7,7 +7,9 @@ from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 class CameraPoseVisualizer:
     def __init__(self, xlim, ylim, zlim):
         self.fig = plt.figure(figsize=(18, 7))
-        self.ax = self.fig.gca(projection='3d')
+        # depricated
+        # self.ax = self.fig.gca(projection='3d') 
+        self.ax = self.fig.add_subplot(projection='3d')
         self.ax.set_aspect("auto")
         self.ax.set_xlim(xlim)
         self.ax.set_ylim(ylim)


### PR DESCRIPTION
Hey, 

I found a single line of code that was deprecated. 

I changed it to add_subplot(projection='3d') as suggested by users online. 

I use this module as a submodule and thought this might help others that try to use this with newer versions of matplotlib. 